### PR TITLE
generate initial corpus for fuzzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,18 @@ make all
 The "setup" target creates common symbolic links and download
 and build llvm fuzzer. It only needs to run once.
 
-The "all" target builds two binaries, test_verifier and test_fuzzer.
-test_verifier is essentially linux/samples/bpf/test_verifier.c with
+The "all" target builds two binaries, `test_verifier` and `test_fuzzer`.
+`test_verifier` is essentially `linux/samples/bpf/test_verifier.c` with
 slight modification to adapt to the new test framework, with
-sanitizer support. test_fuzzer uses llvm fuzzer framework
+sanitizer support. `test_fuzzer` uses llvm fuzzer framework
 for testing.
+
+`test_verifier` can also generate initial test cases for `test_fuzzer`.
+These test cases will make fuzzer more effective in generating relevent
+new test cases.
+```bash
+# generate initial test cases for fuzzer, put them into ./corpus directory
+./test_verifier -g ./corpus
+./test_fuzzer ./corpus
+```
+

--- a/bld/Makefile
+++ b/bld/Makefile
@@ -15,7 +15,7 @@ SRC=$(PWD)/..
 enable_fuzzer_dataflow=1
 
 FUZZER_CFLAGS=-g -O2 -std=c++11
-CFLAGS=-O1 -g -fsanitize=address -fsanitize-coverage=edge -fno-omit-frame-pointer -DTEST_WORKAROUND
+CFLAGS=-O1 -g -fsanitize=address -fsanitize-coverage=edge,8bit-counters -fno-omit-frame-pointer -DTEST_WORKAROUND
 ifeq ($(enable_fuzzer_dataflow),1)
 FUZZER_CFLAGS += -fPIC
 CFLAGS += -fPIC -fsanitize-coverage=trace-cmp
@@ -58,4 +58,4 @@ clean:
 	/bin/rm -rf *.o test_verifier test_fuzzer
 
 distclean:
-	/bin/rm -rf *.i *.h *.c *.o Fuzzer $(KERNEL_TREE_ROOT)/kernel/bpf/linux_hook.c
+	/bin/rm -rf test_verifier test_fuzzer *.i *.h *.c *.o Fuzzer $(KERNEL_TREE_ROOT)/kernel/bpf/linux_hook.c

--- a/src/helper/linux_hook.c
+++ b/src/helper/linux_hook.c
@@ -720,6 +720,26 @@ int bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size,
 	return cur_fd;
 }
 
+void bpf_free_map(int fd)
+{
+	struct bpf_map_node *c, *p;
+
+	c = p = map_head;
+	while (c != NULL) {
+		if (c->fd == fd) {
+			vfree(c->map);
+			if (c == p)
+				map_head = c->next;
+			else
+				p->next = c->next;
+			vfree(c);
+			break;
+		}
+		p = c;
+		c = c->next;
+	}
+}
+
 void bpf_map_put_k(struct bpf_map *map)
 {
 	return;

--- a/src/test/fuzzer/test_fuzzer.c
+++ b/src/test/fuzzer/test_fuzzer.c
@@ -7,27 +7,72 @@
  * modify it under the terms of version 2 of the GNU General Public
  * License as published by the Free Software Foundation.
  */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
 #include <linux/bpf.h>
 
 int bpf_prog_load(enum bpf_prog_type prog_type,
                   const struct bpf_insn *insns, int insn_len,
                   const char *license, int kern_version);
 
-void LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size) {
-        struct bpf_insn *prog = data;
-        int prog_len = size / sizeof(struct bpf_insn);
+int bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size,
+                   int max_entries);
 
-	/* really dummy test, does not handle maps as well. */
+static int create_map(void)
+{
+        long long key, value = 0;
+        int map_fd;
+
+        map_fd = bpf_create_map(BPF_MAP_TYPE_HASH, sizeof(key), sizeof(value), 1024);
+        if (map_fd < 0) {
+                printf("failed to create map '%s'\n", strerror(errno));
+        }
+
+        return map_fd;
+}
+
+void LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size) {
+        struct bpf_insn *prog = data, *prog_c, *insn;
+        int i, prog_len = size / sizeof(struct bpf_insn);
+
+	/* If there are any map instructions, we want to create map now. */
+	insn = prog;
+	for (i = 0; i < prog_len; i++, insn++) {
+		if ((insn[0].code == (BPF_LD | BPF_IMM | BPF_DW)) &&
+		    insn->src_reg == BPF_PSEUDO_MAP_FD) {
+			int map_fd = create_map();
+			insn->imm = map_fd;
+		}
+	}
+	/* keep a copy of instructions since verifier may modify it */
+	prog_c = malloc(size);
+	memcpy(prog_c, data, size);
+
         (void)bpf_prog_load(BPF_PROG_TYPE_SOCKET_FILTER,
                             prog, prog_len * sizeof(struct bpf_insn),
                             "GPL", 0);
+	memcpy(prog, prog_c, size);
         (void)bpf_prog_load(BPF_PROG_TYPE_SCHED_CLS,
                             prog, prog_len * sizeof(struct bpf_insn),
                             "GPL", 0);
+	memcpy(prog, prog_c, size);
         (void)bpf_prog_load(BPF_PROG_TYPE_SCHED_ACT,
                             prog, prog_len * sizeof(struct bpf_insn),
                             "GPL", 0);
+	memcpy(prog, prog_c, size);
         (void)bpf_prog_load(BPF_PROG_TYPE_KPROBE,
                             prog, prog_len * sizeof(struct bpf_insn),
                             "GPL", 0);
+
+	/* remove the created maps */
+	insn = prog_c;
+	for (i = 0; i < prog_len; i++, insn++) {
+		if ((insn[0].code == (BPF_LD | BPF_IMM | BPF_DW)) &&
+		    insn->src_reg == BPF_PSEUDO_MAP_FD) {
+			bpf_free_map(insn->imm);
+		}
+	}
+	free(prog_c);
 }


### PR DESCRIPTION
  o the intial corpus test cases from existing test_verifier tests
  o coverage from fuzzer is indeed improved significantly initially
    after a couple of minutes, the same as no corpus, the coverage
    progress becomes really slow. Need more investigation.

Signed-off-by: Yonghong Song yhs@plumgrid.com
